### PR TITLE
feat(es): improve Search CLI with new commands and safer index manage…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 * feat(dev): add uv and ruff [#21](https://github.com/rero/rero-invenio-base/pull/21) (by @PascalRepond)
 * chore(actions): pypi publish package use poetry [#20](https://github.com/rero/rero-invenio-base/pull/20) (by @PascalRepond)
 
-## [v0.3.1](https://github.com/rero/rero-invenio-base/tree/v0.3.0) (2025-04-16)
+## [v0.3.1](https://github.com/rero/rero-invenio-base/tree/v0.3.1) (2025-04-16)
 
 [Full Changelog](https://github.com/rero/rero-invenio-base/compare/v0.3.0...v0.3.1)
 
@@ -62,15 +62,13 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 ## [v0.2.0](https://github.com/rero/rero-invenio-base/tree/v0.2.0) (2023-01-31)
 
-[Full Changelog](https://github.com/rero/rero-invenio-base/compare/...v0.2.0)
+[Full Changelog](https://github.com/rero/rero-invenio-base/compare/v0.1.0...v0.2.0)
 
 **Changes:**
 
 * task: add a generic celery task [\#10](https://github.com/rero/rero-invenio-base/pull/10) (by @jma)
 
 ## [v0.1.0](https://github.com/rero/rero-invenio-base/tree/v0.1.0) (2022-09-02)
-
-[Full Changelog](https://github.com/rero/rero-invenio-base/compare/...v0.1.0)
 
 **Changes:**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,88 @@
+# rero-invenio-base Claude guide
+
+## Overview
+
+rero-invenio-base is a Python library providing generic backend utilities for RERO Invenio instances. It ships SEARCH CLI management commands, a streaming data export framework, and shared Celery tasks.
+
+**Stack**: Python 3.12–3.14, Flask (Invenio), ElasticSearch 7, Celery
+**Package manager**: `uv` with `poethepoet` for task running
+
+## Commands
+
+All commands are run through uv's virtual env with `uv run`.
+
+### Linting and formatting
+
+**IMPORTANT:** After editing files, make sure that there are no errors in the formatting and linting.
+
+```bash
+uv run poe lint     # ruff check
+uv run poe format   # ruff format
+```
+
+### Setup (done by humans)
+
+Human developers will start the required containers and services on their own terms. Tests require SEARCH to be running.
+
+## Architecture
+
+### Package structure
+
+```text
+rero_invenio_base/
+├── ext.py                    # Flask extension (REROInvenioBase)
+├── config.py                 # Default configuration keys
+├── cli/
+│   ├── shared.py             # Shared CLI helpers (abort_if_false)
+│   ├── utils.py              # check_license, check_json commands
+│   └── es/
+│       ├── alias.py          # `rero es alias` commands
+│       ├── index.py          # `rero es index` commands (reindex, move, update-mapping, …)
+│       ├── task.py           # `rero es task` commands
+│       ├── snapshot/         # `rero es snapshot` commands
+│       └── slm/              # `rero es slm` snapshot-management commands
+└── modules/
+    ├── tasks.py              # run_on_worker Celery task
+    ├── utils.py              # chunk() utility
+    └── export/
+        ├── ext.py            # ReroInvenioBaseExportApp Flask extension
+        ├── views.py          # ExportResource view + create_blueprint_from_app
+        └── config.py         # Export REST endpoint configuration
+```
+
+### Entry points
+
+Registered in `pyproject.toml`:
+
+| Entry point group | Name | Target |
+|---|---|---|
+| `flask.commands` | `rero` | `rero_invenio_base.cli:rero` |
+| `invenio_base.apps` | `rero-invenio-base-export` | `ReroInvenioBaseExportApp` |
+| `invenio_base.api_blueprints` | `rero_ils_exports` | `create_blueprint_from_app` |
+| `invenio_celery.tasks` | `rero` | `rero_invenio_base.modules.tasks` |
+
+### Export module
+
+`ExportResource` is a `ContentNegotiatedMethodView` that streams record search results. Routes are registered dynamically from the `RERO_INVENIO_BASE_EXPORT_REST_ENDPOINTS` config key via `create_blueprint_from_app`. Each endpoint maps MIME types to serializers and prepends `/export` to the list route.
+
+## Code style
+
+- Be clear and concise in docstrings; do not over-comment the code.
+- Do not use Python type annotations (no `-> str`, `: str`, etc. in signatures).
+- Use **Sphinx-style** docstrings (`:param x:`, `:returns:`, `:rtype:`).
+- Commit messages follow [Conventional Commits](https://www.conventionalcommits.org).
+
+## Testing
+
+- Tests use function-based style (no class-based tests).
+- Test fixtures are in `tests/conftest.py`; sample data in `tests/data/`.
+- `--doctest-modules` is active — doctests in module files are run by default.
+
+### Running the tests (done by humans)
+
+Human developers run tests from their consoles after starting the SEARCH container:
+
+```bash
+uv run ./scripts/test   # full suite (lint + pip-audit + pytest with SEARCH)
+uv run pytest           # pytest only (SEARCH must already be running)
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ dev = [
 
 [tool.project.entry-points]
 check_json = "rero_invenio_base.cli.utils:check_json"
-rero = "rero_invenio_base.cli:rero"
 
 [project.entry-points."flask.commands"]
 rero = "rero_invenio_base.cli:rero"

--- a/rero_invenio_base/cli/__init__.py
+++ b/rero_invenio_base/cli/__init__.py
@@ -17,4 +17,4 @@ def rero():
 rero.add_command(utils)
 rero.add_command(es)
 
-__all__ = "rero"
+__all__ = ["rero"]

--- a/rero_invenio_base/cli/es/__init__.py
+++ b/rero_invenio_base/cli/es/__init__.py
@@ -1,12 +1,14 @@
 # SPDX-FileCopyrightText: Fondation RERO+
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-"""Click elasticsearch command-line utilities."""
+"""Click Search command-line utilities."""
 
 import click
 
 from .alias import alias
+from .health import health
 from .index import index
+from .queue import queue
 from .slm import slm
 from .snapshot import snapshot
 from .task import task
@@ -14,13 +16,15 @@ from .task import task
 
 @click.group()
 def es():
-    """Elasticsarch management commands."""
+    """Search management commands."""
 
 
-es.add_command(index)
 es.add_command(alias)
+es.add_command(health)
+es.add_command(index)
+es.add_command(queue)
 es.add_command(slm)
 es.add_command(snapshot)
 es.add_command(task)
 
-__all__ = "index"
+__all__ = ["es"]

--- a/rero_invenio_base/cli/es/alias.py
+++ b/rero_invenio_base/cli/es/alias.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Fondation RERO+
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-"""Click elasticsearch index command-line utilities."""
+"""Click Search index command-line utilities."""
 
 import json
 
@@ -14,13 +14,13 @@ from ..shared import abort_if_false
 
 @click.group()
 def alias():
-    """Elasticsearch alias commands."""
+    """Search alias commands."""
 
 
 @alias.command("get")
 @with_appcontext
 def get_alias():
-    """Get elasticsearch aliases."""
+    """Get Search aliases."""
     click.secho(json.dumps(current_search_client.indices.get_alias(), indent=2), fg="green")
 
 
@@ -29,7 +29,7 @@ def get_alias():
 @click.argument("index")
 @click.argument("name")
 def put_alias(index, name):
-    """Put elasticsearch alias."""
+    """Put Search alias."""
     try:
         click.secho(
             json.dumps(current_search_client.indices.put_alias(index, name), indent=2),
@@ -51,7 +51,7 @@ def put_alias(index, name):
     prompt="Do you really want to delete an alias?",
 )
 def delete_alias(index, name):
-    """Delete elasticsearch alias."""
+    """Delete Search alias."""
     try:
         click.secho(
             json.dumps(current_search_client.indices.delete_alias(index, name), indent=2),

--- a/rero_invenio_base/cli/es/health.py
+++ b/rero_invenio_base/cli/es/health.py
@@ -1,0 +1,75 @@
+# RERO Invenio Base
+# Copyright (C) 2025 RERO.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Click health-check command-line utility."""
+
+from urllib.parse import urlparse, urlunparse
+
+import click
+from flask import current_app
+from flask.cli import with_appcontext
+from invenio_db import db
+from invenio_search import current_search_client
+from sqlalchemy import text
+
+
+@click.command("health")
+@with_appcontext
+def health():
+    """Check connectivity to SEARCH, database, and Redis.
+
+    Exits with status 1 if any service is unreachable or in error state.
+    """
+    all_ok = True
+
+    # SEARCH
+    try:
+        s = current_search_client.cluster.health()
+        color = {"green": "green", "yellow": "yellow"}.get(s["status"], "red")
+        label = "OK" if s["status"] != "red" else "ERROR"
+        detail = f"{s['status'].upper()} — {s['number_of_nodes']} node(s), cluster: {s['cluster_name']}"
+        click.secho(f"{'SEARCH':<12} {label:<7} {detail}", fg=color)
+        if s["status"] == "red":
+            all_ok = False
+    except Exception as err:
+        click.secho(f"{'SEARCH':<12} {'ERROR':<7} {err}", fg="red")
+        all_ok = False
+
+    # Database
+    try:
+        db.session.execute(text("SELECT 1"))
+        click.secho(f"{'Database':<12} {'OK':<7}", fg="green")
+    except Exception as err:
+        click.secho(f"{'Database':<12} {'ERROR':<7} {err}", fg="red")
+        all_ok = False
+
+    # Broker / Redis — use Celery's own connection so any broker type works.
+    try:
+        from celery import current_app as celery_app
+
+        with celery_app.connection() as conn:
+            conn.ensure_connection(max_retries=1)
+        broker_url = current_app.config.get("BROKER_URL") or current_app.config.get("CELERY_BROKER_URL", "")
+        parsed = urlparse(broker_url)
+        host = parsed.hostname or ""
+        netloc = f"{host}:{parsed.port}" if parsed.port else host
+        safe_url = urlunparse(parsed._replace(netloc=netloc))
+        click.secho(f"{'Broker':<12} {'OK':<7} {safe_url[:60]}", fg="green")
+    except Exception as err:
+        click.secho(f"{'Broker':<12} {'ERROR':<7} {err}", fg="red")
+        all_ok = False
+
+    if not all_ok:
+        raise SystemExit(1)

--- a/rero_invenio_base/cli/es/index.py
+++ b/rero_invenio_base/cli/es/index.py
@@ -1,15 +1,16 @@
 # SPDX-FileCopyrightText: Fondation RERO+
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-"""Click elasticsearch index command-line utilities."""
+"""Click Search index command-line utilities."""
 
 import json
 import sys
+from datetime import UTC, datetime
 from pprint import pformat
 from time import sleep
 
 import click
-from elasticsearch_dsl import Index
+from elasticsearch import NotFoundError
 from invenio_search import current_search, current_search_client
 
 try:
@@ -21,9 +22,100 @@ from invenio_search.cli import with_appcontext
 from jsonpatch import make_patch
 
 
+def _create_index_from_mapping(index_name, f_mapping):
+    """Create an Search index from a mapping file."""
+    with open(f_mapping) as mapping_file:
+        mapping = json.load(mapping_file)
+    current_search_client.indices.create(index=index_name, body=mapping)
+
+
+def _watch_reindex_task(task, interval, verbose):
+    """Poll a reindex task until completion.
+
+    :param task: task id returned by the reindex API.
+    :param interval: seconds between polls.
+    :param verbose: print task progress on each poll.
+    :returns: True on success, False if the task reported failures.
+    """
+    count = 0
+    res = current_search_client.tasks.get(task)
+    while not res.get("completed"):
+        task_info = res.get("task")
+        if verbose and task_info:
+            click.secho(f"Watching task: {task} {count} seconds ...", fg="green")
+            click.secho(f"{task_info.get('description')}", fg="green")
+            click.secho(f"{pformat(task_info.get('status'))}", fg="green")
+        sleep(interval)
+        count += interval
+        res = current_search_client.tasks.get(task)
+    if verbose:
+        click.secho(f"Finished task: {task} {count} seconds ...", fg="yellow")
+        click.secho(f"{pformat(res.get('response'))}", fg="yellow")
+    if failures := res.get("response", {}).get("failures"):
+        click.secho(f"ERROR REINDEX: {failures}", fg="red")
+        return False
+    return True
+
+
+def _do_reindex(src, dest, interval, verbose, label="Task"):
+    """Submit a reindex task and optionally wait for it.
+
+    :param src: source index name.
+    :param dest: destination index name.
+    :param interval: seconds between polls (0 = fire and forget).
+    :param verbose: print task progress on each poll.
+    :param label: prefix shown before the task id.
+    :returns: True on success or when fire-and-forget, False on task failures.
+    """
+    res = current_search_client.reindex(
+        body={
+            "source": {"index": src},
+            "dest": {"index": dest, "version_type": "external_gte"},
+        },
+        wait_for_completion=False,
+    )
+    task = res["task"]
+    click.secho(f"{label}: {task}", fg="green")
+    if interval > 0:
+        return _watch_reindex_task(task, interval, verbose)
+    return True
+
+
+def _switch_aliases(from_index, to_index):
+    """Move all aliases from one index to another.
+
+    :param from_index: index that currently holds the aliases.
+    :param to_index: index that should receive the aliases.
+    :returns: list of alias names that were moved.
+    """
+    aliases = list(current_search_client.indices.get_alias().get(from_index, {}).get("aliases", {}).keys())
+    for alias in aliases:
+        current_search_client.indices.put_alias(to_index, alias)
+        current_search_client.indices.delete_alias(from_index, alias)
+        click.secho(f"Alias '{alias}' → {to_index}.", fg="green")
+    return aliases
+
+
+def _update_templates(verbose, templates):
+    """Update Search templates if requested."""
+    if not templates:
+        return
+    tbody = current_search_client.indices.get_template()
+    for tmpl in current_search.put_templates():
+        click.secho(f"file:{tmpl[0]}, ok: {tmpl[1]}", fg="green")
+        new_tbody = current_search_client.indices.get_template()
+        if patch := make_patch(tbody, new_tbody):
+            click.secho("Templates are updated.", fg="green")
+            if verbose:
+                click.secho("Diff in templates", fg="green")
+                click.echo(patch)
+        else:
+            click.secho("Templates did not change.", fg="yellow")
+
+
 @click.group()
 def index():
-    """Elasticsearch index commands."""
+    """Search index commands."""
 
 
 @index.command("reindex")
@@ -48,24 +140,34 @@ def reindex(source, destination):
 
 @index.command("open")
 @with_appcontext
-@click.option("-i", "--index", help="default=_all", default="_all")
+@click.option("-i", "--index", help="default=_all", default="*")
 def open_index(index):
-    """Open elasticsearch index."""
+    """Open Search index."""
     try:
-        i = Index(index, using=current_search_client)
-        click.secho(json.dumps(i.open(), indent=2), fg="green")
+        click.secho(
+            json.dumps(
+                current_search_client.indices.open(index=index, allow_no_indices=True, ignore_unavailable=True),
+                indent=2,
+            ),
+            fg="green",
+        )
     except Exception as err:
         click.secho(str(err), fg="red")
 
 
 @index.command("close")
 @with_appcontext
-@click.option("-i", "--index", help="default=_all", default="_all")
+@click.option("-i", "--index", help="default=_all", default="*")
 def close_index(index):
-    """Close elasticsearch index."""
+    """Close Search index."""
     try:
-        i = Index(index, using=current_search_client)
-        click.secho(json.dumps(i.close(), indent=2), fg="green")
+        click.secho(
+            json.dumps(
+                current_search_client.indices.close(index=index, allow_no_indices=True, ignore_unavailable=True),
+                indent=2,
+            ),
+            fg="green",
+        )
     except Exception as err:
         click.secho(str(err), fg="red")
 
@@ -76,16 +178,17 @@ def close_index(index):
 @click.argument("old")
 @click.argument("new")
 def switch_index(old, new):
-    """Switch index using the elasticsearch aliases.
+    """Switch index using the Search aliases.
 
     :param old: full name of the old index
     :param new: full name of the fresh created index
     """
-    aliases = current_search_client.indices.get_alias().get(old).get("aliases").keys()
-    for alias in aliases:
-        current_search_client.indices.put_alias(new, alias)
-        current_search_client.indices.delete_alias(old, alias)
-    click.secho("Successfully switched.", fg="green")
+    try:
+        _switch_aliases(old, new)
+        click.secho("Successfully switched.", fg="green")
+    except Exception as err:
+        click.secho(f"ERROR SWITCH: {err}", fg="red")
+        sys.exit(1)
 
 
 @index.command("create")
@@ -103,18 +206,7 @@ def create_index(resource, index, verbose, templates):
     :param verbose: display additional message.
     :param templates: update also the es templates.
     """
-    if templates:
-        tbody = current_search_client.indices.get_template()
-        for tmpl in current_search.put_templates():
-            click.secho(f"file:{tmpl[0]}, ok: {tmpl[1]}", fg="green")
-            new_tbody = current_search_client.indices.get_template()
-            if patch := make_patch(new_tbody, tbody):
-                click.secho("Templates are updated.", fg="green")
-                if verbose:
-                    click.secho("Diff in templates", fg="green")
-                    click.echo(patch)
-            else:
-                click.secho("Templates did not changed.", fg="yellow")
+    _update_templates(verbose, templates)
 
     f_mapping = list(current_search.aliases.get(resource).values()).pop()
     with open(f_mapping) as mapping:
@@ -158,7 +250,7 @@ def update_mapping(aliases, settings):
 @click.option("-v", "--verbose/--no-verbose", "verbose", is_flag=True, default=False)
 @click.option("-n", "--interval", default=1, type=int, help="seconds to wait between updates")
 def move_index(resource, old, new, templates, verbose, interval):
-    """Move index using the elasticsearch resource.
+    """Move index using the Search resource.
 
     :param resource: the resource such as documents.
     :param old: full name of the old index
@@ -166,70 +258,209 @@ def move_index(resource, old, new, templates, verbose, interval):
     :param verbose: display additional message.
     :param templates: update also the es templates.
     """
-    # create_index(resource, index, verbose, templates)
     try:
-        if templates:
-            tbody = current_search_client.indices.get_template()
-            for tmpl in current_search.put_templates():
-                click.secho(f"file:{tmpl[0]}, ok: {tmpl[1]}", fg="green")
-                new_tbody = current_search_client.indices.get_template()
-                if patch := make_patch(new_tbody, tbody):
-                    click.secho("Templates are updated.", fg="green")
-                    if verbose:
-                        click.secho("Diff in templates", fg="green")
-                        click.echo(patch)
-                else:
-                    click.secho("Templates did not changed.", fg="yellow")
-
+        _update_templates(verbose, templates)
         f_mapping = list(current_search.aliases.get(resource).values()).pop()
-        with open(f_mapping) as mapping:
-            mapping = json.load(mapping)
-        current_search_client.indices.create(new, mapping)
+        _create_index_from_mapping(new, f_mapping)
         click.secho(f"Index {new} has been created.", fg="green")
     except Exception as err:
         click.secho(f"ERROR CREATE: {err}", fg="red")
         sys.exit(1)
 
-    res = current_search_client.reindex(
-        body={
-            "source": {"index": old},
-            "dest": {"index": new, "version_type": "external_gte"},
-        },
-        wait_for_completion=False,
-    )
-    task = res["task"]
-    click.secho(f"Task: {task}", fg="green")
-    if interval == 0:
-        return
-    count = 0
-    # wait for task
-    res = current_search_client.tasks.get(task)
-    while not res.get("completed"):
-        task_info = res.get("task")
-        if verbose and task_info:
-            click.secho(f"Watching task: {task} {count} seconds ...", fg="green")
-            click.secho(f"{task_info.get('description')}", fg="green")
-            click.secho(f"{pformat(task_info.get('status'))}", fg="green")
-        sleep(interval)
-        count += interval
-        res = current_search_client.tasks.get(task)
-    if verbose:
-        click.secho(f"Finished task: {task} {count} seconds ...", fg="yellow")
-        click.secho(f"{pformat(res.get('response'))}", fg="yellow")
-    if failures := res.get("failures"):
-        click.secho(f"ERROR REINDEX: {failures}", fg="red")
+    if not _do_reindex(old, new, interval, verbose):
         sys.exit(2)
 
-    # switch index
     try:
-        aliases = current_search_client.indices.get_alias().get(old).get("aliases").keys()
-        for alias in aliases:
-            current_search_client.indices.put_alias(new, alias)
-            current_search_client.indices.delete_alias(old, alias)
+        _switch_aliases(old, new)
         click.secho("Successfully switched.", fg="green")
     except Exception as err:
         click.secho(f"ERROR SWITCH: {err}", fg="red")
         sys.exit(3)
+
+
+def _reindex_pass(src, dest, interval, verbose, label, src_label, dest_label, confirm_msg, abort_msg, exit_base):
+    """Reindex src→dest, display counts, ask for confirmation, switch aliases, delete src.
+
+    :param src: source index.
+    :param dest: destination index.
+    :param interval: seconds between reindex task polls (0 = fire and forget).
+    :param verbose: show reindex task progress.
+    :param label: prefix shown before the reindex task id.
+    :param src_label: short description of src shown in the count line.
+    :param dest_label: short description of dest shown in the count line.
+    :param confirm_msg: text passed to click.confirm.
+    :param abort_msg: message printed when the user declines.
+    :param exit_base: base exit code; switch failure = exit_base+1, delete failure = exit_base+2.
+    :returns: True if completed, False if the user aborted.
+    """
+    if not _do_reindex(src, dest, interval, verbose, label=label):
+        sys.exit(exit_base)
+
+    src_count = current_search_client.count(index=src).get("count", "?")
+    dest_count = current_search_client.count(index=dest).get("count", "?")
+    click.secho(f"  {src}: {src_count} docs  ({src_label})", fg="yellow")
+    click.secho(f"  {dest}: {dest_count} docs  ({dest_label})", fg="green")
+
+    if not click.confirm(confirm_msg):
+        click.secho(abort_msg, fg="yellow")
+        return False
+
+    try:
+        _switch_aliases(src, dest)
+    except Exception as err:
+        click.secho(f"ERROR SWITCH: {err}", fg="red")
+        sys.exit(exit_base + 1)
+
+    try:
+        current_search_client.indices.delete(index=src)
+        click.secho(f"Index {src} deleted.", fg="green")
+    except Exception as err:
+        click.secho(f"ERROR DELETE: {err}", fg="red")
+        sys.exit(exit_base + 2)
+
+    return True
+
+
+def _create_fresh(resource, new_index, f_mapping):
+    """Bootstrap a resource that has no index yet: create it and register the alias.
+
+    :param resource: alias name to register.
+    :param new_index: index name to create.
+    :param f_mapping: path to the mapping file.
+    """
+    if current_search_client.indices.exists(index=new_index):
+        click.secho(f"Index {new_index} already exists but alias '{resource}' is not set. Aborting.", fg="red")
+        sys.exit(1)
+    click.secho(f"No existing index for '{resource}'. Creating {new_index}...", fg="yellow")
+    try:
+        _create_index_from_mapping(new_index, f_mapping)
+        current_search_client.indices.put_alias(index=new_index, name=resource)
+        click.secho(f"Index {new_index} created, alias '{resource}' registered.", fg="green")
+    except Exception as err:
+        click.secho(f"ERROR CREATE: {err}", fg="red")
+        sys.exit(1)
+
+
+def _create_and_log(index_name, f_mapping, exit_code):
+    """Create an index from mapping, log the result, and exit on failure.
+
+    :param index_name: name of the index to create.
+    :param f_mapping: path to the mapping file.
+    :param exit_code: exit code used when the creation fails.
+    """
+    try:
+        _create_index_from_mapping(index_name, f_mapping)
+        click.secho(f"Index {index_name} created.", fg="green")
+    except Exception as err:
+        click.secho(f"ERROR CREATE: {err}", fg="red")
+        sys.exit(exit_code)
+
+
+@index.command("rebuild")
+@with_appcontext
+@es_version_check
+@click.argument("resource")
+@click.option("-t", "--templates/--no-templates", "templates", is_flag=True, default=True)
+@click.option("-v", "--verbose/--no-verbose", "verbose", is_flag=True, default=False)
+@click.option("-i", "--interval", default=1, type=int, help="seconds to wait between task updates")
+@click.option(
+    "-n", "--name", default=None, help="Override the destination index name (default: registered name + today's date)."
+)
+@click.option(
+    "-i",
+    "--inplace",
+    is_flag=True,
+    default=False,
+    help="Rebuild keeping the same index name (double-move via temp index).",
+)
+def rebuild_index(resource, templates, verbose, interval, name, inplace):
+    """Reindex a resource into an up-to-date index without data loss.
+
+    Normal mode (default): migrate directly ``old → new_index`` where
+    ``new_index`` is the registered name suffixed with today's date.
+
+    Inplace mode (``--inplace``): rebuild under the same index name.  A temporary
+    index is used so the alias always points to a live index: ``old → tmp`` first,
+    then ``tmp → old`` after the original index is recreated fresh.
+
+    :param resource: alias name, e.g. 'patrons'.
+    :param templates: update Search templates before rebuilding.
+    :param verbose: show template diffs and reindex task progress.
+    :param interval: seconds between reindex task updates (0 = fire and forget).
+    :param name: explicit destination index name; defaults to registered name + today's date.
+    :param inplace: evacuate the current index to a temp before migrating to new_index.
+    """
+    alias_map = current_search.aliases.get(resource)
+    if not alias_map:
+        click.secho(f"Unknown resource: '{resource}'.", fg="red")
+        click.secho(f"Available: {', '.join(sorted(current_search.aliases))}", fg="yellow")
+        sys.exit(1)
+
+    registered_index, f_mapping = next(iter(alias_map.items()))
+    new_index = name or f"{registered_index}-{datetime.now(UTC).strftime('%Y%m%d')}"
+
+    try:
+        old_indices = list(current_search_client.indices.get_alias(name=resource).keys())
+    except NotFoundError:
+        old_indices = []
+
+    try:
+        _update_templates(verbose, templates)
+    except Exception as err:
+        click.secho(f"ERROR TEMPLATES: {err}", fg="red")
+        sys.exit(1)
+
+    if not old_indices:
+        _create_fresh(resource, new_index, f_mapping)
+        return
+
+    old_index = old_indices[0]
+
+    if inplace:
+        tmp_index = f"{old_index}-tmp-{datetime.now(UTC).strftime('%Y%m%d%H%M%S')}"
+        click.secho(f"Rebuilding '{resource}' in place: {old_index} → {tmp_index} → {old_index}", fg="green")
+        _create_and_log(tmp_index, f_mapping, exit_code=1)
+        if not _reindex_pass(
+            src=old_index,
+            dest=tmp_index,
+            interval=interval,
+            verbose=verbose,
+            label="Task (pass 1)",
+            src_label="current",
+            dest_label="temp",
+            confirm_msg=f"Move '{old_index}' to temp before rebuilding?",
+            abort_msg=f"Aborted. Temp index {tmp_index} exists — delete it manually when done.",
+            exit_base=2,
+        ):
+            return
+        src = tmp_index
+        final_dest = old_index
+        exit_base = 5
+    else:
+        if old_index == new_index:
+            click.secho(f"'{resource}' already points to {new_index}. Nothing to do.", fg="green")
+            return
+        if current_search_client.indices.exists(index=new_index):
+            click.secho(f"Index {new_index} already exists. Aborting.", fg="red")
+            sys.exit(1)
+        click.secho(f"Rebuilding '{resource}': {old_index} → {new_index}", fg="green")
+        src = old_index
+        final_dest = new_index
+        exit_base = 2
+
+    _create_and_log(final_dest, f_mapping, exit_code=exit_base - 1)
+    _reindex_pass(
+        src=src,
+        dest=final_dest,
+        interval=interval,
+        verbose=verbose,
+        label="Task (pass 2)" if inplace else "Task",
+        src_label="temp" if inplace else "old",
+        dest_label="rebuilt" if inplace else "new",
+        confirm_msg="Switch alias back and delete temp index?" if inplace else "Switch alias and delete source index?",
+        abort_msg=f"Aborted. {final_dest} was created but alias still points to {src}.",
+        exit_base=exit_base,
+    )
 
 
 @index.command()

--- a/rero_invenio_base/cli/es/queue.py
+++ b/rero_invenio_base/cli/es/queue.py
@@ -1,0 +1,124 @@
+# RERO Invenio Base
+# Copyright (C) 2025 RERO.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Click Celery queue command-line utilities."""
+
+import json
+
+import click
+from celery import current_app as celery_app
+from flask.cli import with_appcontext
+
+from ..shared import abort_if_false
+
+
+@click.group()
+def queue():
+    """Celery queue commands."""
+
+
+@queue.command("list")
+@with_appcontext
+@click.option(
+    "-t",
+    "--timeout",
+    default=5.0,
+    type=float,
+    help="Worker inspect timeout in seconds.",
+)
+def queue_list(timeout):
+    """List Celery workers with their active, reserved, and scheduled task counts."""
+    inspect = celery_app.control.inspect(timeout=timeout)
+    stats = inspect.stats() or {}
+    if not stats:
+        click.secho(f"No workers responded within {timeout}s.", fg="yellow")
+        return
+
+    active = inspect.active() or {}
+    reserved = inspect.reserved() or {}
+    scheduled = inspect.scheduled() or {}
+
+    click.secho(
+        f"  {'WORKER':<44}  {'ACTIVE':>6}  {'RESERVED':>8}  {'SCHEDULED':>9}",
+        bold=True,
+    )
+    for worker in sorted(stats):
+        n_active = len(active.get(worker, []))
+        n_reserved = len(reserved.get(worker, []))
+        n_scheduled = len(scheduled.get(worker, []))
+        color = "green" if (n_active or n_reserved) else None
+        click.secho(
+            f"  {worker:<44}  {n_active:>6}  {n_reserved:>8}  {n_scheduled:>9}",
+            fg=color,
+        )
+
+    # Queue depths via broker connection (works for Redis and AMQP)
+    try:
+        queue_names = {celery_app.conf.task_default_queue or "celery"}
+        for q in celery_app.conf.task_queues or []:
+            queue_names.add(q.name if hasattr(q, "name") else str(q))
+
+        click.secho(f"\n  {'QUEUE':<30}  {'DEPTH':>6}", bold=True)
+        with celery_app.connection() as conn:
+            for q_name in sorted(queue_names):
+                try:
+                    depth = conn.default_channel.queue_declare(q_name, passive=True).message_count
+                except Exception:
+                    depth = "?"
+                color = "yellow" if depth and depth != "?" and depth > 0 else None
+                click.secho(f"  {q_name:<30}  {depth!s:>6}", fg=color)
+    except Exception as err:
+        click.secho(f"\nCould not read queue depths: {err}", fg="yellow")
+
+
+@queue.command("stats")
+@with_appcontext
+@click.option(
+    "-t",
+    "--timeout",
+    default=5.0,
+    type=float,
+    help="Worker inspect timeout in seconds.",
+)
+def queue_stats(timeout):
+    """Show detailed Celery worker statistics as JSON."""
+    stats = celery_app.control.inspect(timeout=timeout).stats() or {}
+    if not stats:
+        click.secho(f"No workers responded within {timeout}s.", fg="yellow")
+        return
+    click.secho(json.dumps(stats, indent=2, default=str), fg="green")
+
+
+@queue.command("purge")
+@with_appcontext
+@click.argument("queue_name", default="celery")
+@click.option(
+    "--yes-i-know",
+    is_flag=True,
+    callback=abort_if_false,
+    expose_value=False,
+    prompt="Do you really want to purge this queue?",
+)
+def queue_purge(queue_name):
+    """Purge all pending tasks from a named queue.
+
+    :param queue_name: name of the queue to purge (default: celery).
+    """
+    try:
+        with celery_app.connection() as conn:
+            n = conn.default_channel.queue_purge(queue_name)
+        click.secho(f"Purged {n} task(s) from '{queue_name}'.", fg="yellow")
+    except Exception as err:
+        click.secho(f"Error: {err}", fg="red")

--- a/rero_invenio_base/cli/es/slm/__init__.py
+++ b/rero_invenio_base/cli/es/slm/__init__.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Fondation RERO+
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-"""Click elasticsearch command-line snapshot lifecycle management."""
+"""Click Search command-line snapshot lifecycle management."""
 
 from .cli import slm
 

--- a/rero_invenio_base/cli/es/slm/cli.py
+++ b/rero_invenio_base/cli/es/slm/cli.py
@@ -1,10 +1,9 @@
 # SPDX-FileCopyrightText: Fondation RERO+
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-"""Click elasticsearch snapshot command-line utilities."""
+"""Click Search snapshot lifecycle management (SLM) command-line utilities."""
 
 import json
-import sys
 
 import click
 from elasticsearch import TransportError
@@ -16,7 +15,7 @@ from ...shared import abort_if_false
 
 @click.group()
 def slm():
-    """Elasticsearch snapshot lifecycle management commands."""
+    """Search snapshot lifecycle management commands."""
 
 
 @slm.command()
@@ -27,10 +26,10 @@ def stats():
         click.secho(json.dumps(current_search_client.slm.get_stats(), indent=2), fg="green")
     except TransportError as err:
         click.secho(f"SLM NOT ENABLED: {err}", fg="red")
-        sys.exit(1)
+        raise click.Abort() from err
     except Exception as err:
         click.secho(str(err), fg="red")
-        sys.exit(1)
+        raise click.Abort() from err
 
 
 @slm.command()
@@ -41,10 +40,10 @@ def status():
         click.secho(json.dumps(current_search_client.slm.get_status(), indent=2), fg="green")
     except TransportError as err:
         click.secho(f"SLM NOT ENABLED: {err}", fg="red")
-        sys.exit(1)
+        raise click.Abort() from err
     except Exception as err:
         click.secho(str(err), fg="red")
-        sys.exit(1)
+        raise click.Abort() from err
 
 
 @slm.command()
@@ -55,10 +54,10 @@ def start():
         click.secho(json.dumps(current_search_client.slm.start(), indent=2), fg="green")
     except TransportError as err:
         click.secho(f"SLM NOT ENABLED: {err}", fg="red")
-        click.Abort
+        raise click.Abort() from err
     except Exception as err:
         click.secho(str(err), fg="red")
-        click.Abort
+        raise click.Abort() from err
 
 
 @slm.command()
@@ -76,10 +75,10 @@ def stop():
         click.secho(json.dumps(current_search_client.slm.stop(), indent=2), fg="red")
     except TransportError as err:
         click.secho(f"SLM NOT ENABLED: {err}", fg="red")
-        click.Abort
+        raise click.Abort() from err
     except Exception as err:
         click.secho(str(err), fg="red")
-        click.Abort
+        raise click.Abort() from err
 
 
 @slm.command()
@@ -101,10 +100,10 @@ def delete(policy_id):
         )
     except TransportError as err:
         click.secho(f"SLM NOT ENABLED: {err}", fg="red")
-        click.Abort
+        raise click.Abort() from err
     except Exception as err:
         click.secho(str(err), fg="red")
-        click.Abort
+        raise click.Abort() from err
 
 
 @slm.command()
@@ -119,10 +118,10 @@ def execute(policy_id):
         )
     except TransportError as err:
         click.secho(f"SLM NOT ENABLED: {err}", fg="red")
-        click.Abort
+        raise click.Abort() from err
     except Exception as err:
         click.secho(str(err), fg="red")
-        click.Abort
+        raise click.Abort() from err
 
 
 @slm.command()
@@ -137,10 +136,10 @@ def get(name):
         )
     except TransportError as err:
         click.secho(f"SLM NOT ENABLED: {err}", fg="red")
-        click.Abort
+        raise click.Abort() from err
     except Exception as err:
         click.secho(str(err), fg="red")
-        click.Abort
+        raise click.Abort() from err
 
 
 @slm.command()
@@ -157,7 +156,7 @@ def put(policy_id, body_file):
         )
     except TransportError as err:
         click.secho(f"SLM NOT ENABLED: {err}", fg="red")
-        click.Abort
+        raise click.Abort() from err
     except Exception as err:
         click.secho(str(err), fg="red")
-        click.Abort
+        raise click.Abort() from err

--- a/rero_invenio_base/cli/es/snapshot/cli.py
+++ b/rero_invenio_base/cli/es/snapshot/cli.py
@@ -1,23 +1,63 @@
 # SPDX-FileCopyrightText: Fondation RERO+
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-"""Click elasticsearch snapshot command-line utilities."""
+"""Click Search snapshot command-line utilities."""
 
 import json
 from datetime import UTC, datetime
 
 import click
-from elasticsearch_dsl import Index
 from flask.cli import with_appcontext
 from invenio_search import current_search, current_search_client
 
 from ...shared import abort_if_false
 from .repository import repository
 
+_STATE_COLORS = {
+    "SUCCESS": "green",
+    "PARTIAL": "yellow",
+    "FAILED": "red",
+    "IN_PROGRESS": "blue",
+}
+
+
+def _print_snapshot_table(snapshots_list):
+    """Render a condensed snapshot table to the terminal."""
+    if not snapshots_list:
+        click.secho("No snapshots found.", fg="yellow")
+        return
+    name_width = max(len(s["snapshot"]) for s in snapshots_list)
+    click.secho(
+        f"  {'SNAPSHOT':<{name_width}}  {'START TIME':<30}  {'DURATION':>10}  SHARDS   STATE",
+        bold=True,
+    )
+    for snap in snapshots_list:
+        state = snap["state"]
+        shards = snap["shards"]
+        shards_str = f"{shards.get('successful', 0)}/{shards.get('total', 0)}"
+        line = (
+            f"  {snap['snapshot']:<{name_width}}"
+            f"  {snap['start_time']:<30}"
+            f"  {snap['duration']:>9.1f}s"
+            f"  {shards_str:<7}  "
+        )
+        click.echo(line, nl=False)
+        click.secho(state, fg=_STATE_COLORS.get(state))
+
+
+def _print_response(res):
+    """Print an API response, using plain messages for simple acknowledgements."""
+    if res.get("accepted"):
+        click.secho("Accepted.", fg="green")
+    elif res.get("acknowledged"):
+        click.secho("Acknowledged.", fg="green")
+    else:
+        click.secho(json.dumps(res, indent=2), fg="green")
+
 
 @click.group()
 def snapshot():
-    """Elasticsearch snapshot commands."""
+    """SEARCH snapshot commands."""
 
 
 snapshot.add_command(repository)
@@ -25,26 +65,36 @@ snapshot.add_command(repository)
 
 @snapshot.command("list")
 @with_appcontext
-@click.option("-n", "--name", help="default=_all", default="_all")
+@click.option("-n", "--name", default="_all", help="Snapshot name or pattern. Defaults to _all.")
+@click.option("-N", "--names-only", is_flag=True, default=False, help="Print only snapshot names, one per line.")
 @click.argument("repository")
-def list_snapshot(repository, name):
-    """List snapshot."""
+def list_snapshot(repository, name, names_only):
+    """List snapshots in a repository.
+
+    When NAME is _all (the default), snapshots are shown as a formatted table.
+    Pass a specific snapshot name to see its full details as JSON.
+    """
     try:
         snapshots = current_search_client.snapshot.get(repository, name)
-        infos = snapshots
         if name == "_all":
-            infos = [
+            snap_list = [
                 {
-                    "snapshot": snapshot["snapshot"],
-                    "start_time": snapshot["start_time"],
-                    "duration": snapshot["duration_in_millis"] / 1000,
-                    "shards": snapshot["shards"],
-                    "state": snapshot["state"],
-                    "uuid": snapshot["uuid"],
+                    "snapshot": s["snapshot"],
+                    "start_time": s["start_time"],
+                    "duration": s["duration_in_millis"] / 1000,
+                    "shards": s["shards"],
+                    "state": s["state"],
+                    "uuid": s["uuid"],
                 }
-                for snapshot in snapshots["snapshots"]
+                for s in snapshots["snapshots"]
             ]
-        click.secho(json.dumps(infos, indent=2), fg="green")
+            if names_only:
+                for s in snap_list:
+                    click.echo(s["snapshot"])
+            else:
+                _print_snapshot_table(snap_list)
+        else:
+            click.secho(json.dumps(snapshots, indent=2), fg="green")
     except Exception as err:
         click.secho(str(err), fg="red")
 
@@ -55,27 +105,37 @@ def list_snapshot(repository, name):
 @click.option(
     "-n",
     "--name",
-    help="default={YYYY.MM.DD_HH:MM:SS}",
     default=datetime.now(UTC).strftime("%Y.%m.%d_%H:%M:%S"),
+    help="Snapshot name. Defaults to the current UTC timestamp (YYYY.MM.DD_HH:MM:SS).",
 )
-@click.option("-w", "--wait", help="wait=True", is_flag=True, default=False)
+@click.option("-w", "--wait", is_flag=True, default=False, help="Wait for the snapshot to complete before returning.")
 def create_snapshot(repository, name, wait):
-    """Create a new snapshot."""
+    """Create a snapshot of all RERO ILS indices.
+
+    Captures all indices registered in the application aliases plus
+    events-stats-record-view*. Global cluster state is excluded.
+    """
     indices = [f"{v}*" for v in current_search.aliases] + ["events-stats-record-view*"]
     try:
-        click.secho(
-            json.dumps(
-                current_search_client.snapshot.create(
-                    repository,
-                    name,
-                    body={"indices": ",".join(indices), "include_global_state": False},
-                    wait_for_completion=wait,
-                    master_timeout="5m",
-                ),
-                indent=2,
-            ),
-            fg="green",
+        res = current_search_client.snapshot.create(
+            repository,
+            name,
+            body={"indices": ",".join(indices), "include_global_state": False},
+            wait_for_completion=wait,
+            master_timeout="5m",
         )
+        if wait:
+            snap = res.get("snapshot", {})
+            state = snap.get("state", "UNKNOWN")
+            duration = snap.get("duration_in_millis", 0) / 1000
+            shards = snap.get("shards", {})
+            shards_str = f"{shards.get('successful', 0)}/{shards.get('total', 0)}"
+            click.secho(f"Snapshot:  {snap.get('snapshot')}", fg=_STATE_COLORS.get(state))
+            click.echo(f"State:     {state}")
+            click.echo(f"Duration:  {duration:.1f}s")
+            click.echo(f"Shards:    {shards_str}")
+        else:
+            _print_response(res)
     except Exception as err:
         click.secho(str(err), fg="red")
 
@@ -92,12 +152,9 @@ def create_snapshot(repository, name, wait):
     prompt="Do you really want to delete a snapshot?",
 )
 def delete_snapshot(repository, name):
-    """Delete a snapshot."""
+    """Delete a snapshot from a repository."""
     try:
-        click.secho(
-            json.dumps(current_search_client.snapshot.delete(repository, name), indent=2),
-            fg="red",
-        )
+        _print_response(current_search_client.snapshot.delete(repository, name))
     except Exception as err:
         click.secho(str(err), fg="red")
 
@@ -106,23 +163,57 @@ def delete_snapshot(repository, name):
 @with_appcontext
 @click.argument("repository")
 @click.argument("name")
-@click.option("-w", "--wait", help="wait=True", is_flag=True, default=False)
-def restore_snapshot(repository, name, wait):
-    """Restore a snapshot."""
+@click.option("-w", "--wait", is_flag=True, default=False, help="Wait for the restore to complete before returning.")
+@click.option(
+    "-d",
+    "--delete",
+    "delete_indices",
+    is_flag=True,
+    default=False,
+    help=(
+        "Delete RERO ILS indices before restoring instead of closing all cluster indices. "
+        "Safer for production: system and Search Dashboards indices are left untouched."
+    ),
+)
+@click.option(
+    "--yes-i-know",
+    is_flag=True,
+    callback=abort_if_false,
+    expose_value=False,
+    prompt="Do you really want to restore this snapshot? This will disrupt or delete existing indices.",
+)
+def restore_snapshot(repository, name, wait, delete_indices):
+    """Restore a snapshot into the cluster.
+
+    By default all cluster indices are closed before the restore and reopened
+    afterwards (required by SEARCH when restoring to existing indices).
+
+    With --delete, only RERO ILS indices (application aliases +
+    events-stats-record-view*) are deleted beforehand. This avoids touching
+    system or SEARCH Dashboards indices that are not part of the snapshot.
+    """
     try:
-        i = Index("_all", using=current_search_client)
-        click.secho("Closing all indices...", fg="")
-        i.close()
-        click.secho("All indices are closed.")
-        click.secho(
-            json.dumps(
-                current_search_client.snapshot.restore(repository, name, master_timeout="5m", wait_for_completion=wait),
-                indent=2,
-            ),
-            fg="green",
+        if delete_indices:
+            rero_indices = ",".join([f"{v}*" for v in current_search.aliases] + ["events-stats-record-view*"])
+            click.secho(f"Indices to delete: {rero_indices}", fg="yellow")
+            if not click.confirm("Confirm deletion of the above indices before restore?"):
+                raise click.Abort()
+            current_search_client.indices.delete(index=rero_indices, allow_no_indices=True, ignore_unavailable=True)
+            click.secho("RERO ILS indices deleted.")
+        else:
+            current_search_client.indices.close(index="*", allow_no_indices=True, ignore_unavailable=True)
+            click.secho("All indices are closed.")
+        _print_response(
+            current_search_client.snapshot.restore(repository, name, master_timeout="5m", wait_for_completion=wait)
         )
-        click.secho("Opening all indices...")
-        i.open()
-        click.secho("All indices are open.")
+        if not delete_indices:
+            if wait:
+                click.secho("Opening all indices...")
+                current_search_client.indices.open(index="*", allow_no_indices=True, ignore_unavailable=True)
+                click.secho("All indices are open.")
+            else:
+                click.secho("Restore running in background. Open indices manually once complete.")
+    except click.Abort:
+        raise
     except Exception as err:
         click.secho(str(err), fg="red")

--- a/rero_invenio_base/cli/es/snapshot/repository.py
+++ b/rero_invenio_base/cli/es/snapshot/repository.py
@@ -1,9 +1,10 @@
 # SPDX-FileCopyrightText: Fondation RERO+
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-"""Click elasticsearch snapshot repository command-line utilities."""
+"""Click Search snapshot repository command-line utilities."""
 
 import json
+import os
 
 import click
 from flask.cli import with_appcontext
@@ -14,13 +15,13 @@ from ...shared import abort_if_false
 
 @click.group()
 def repository():
-    """Elasticsearch repository commands."""
+    """SEARCH snapshot repository commands."""
 
 
 @repository.command("list")
 @with_appcontext
 def list_repository():
-    """List repository."""
+    """List all registered snapshot repositories."""
     try:
         click.secho(
             json.dumps(current_search_client.snapshot.get_repository(), indent=2),
@@ -34,13 +35,17 @@ def list_repository():
 @with_appcontext
 @click.argument("repository")
 @click.argument("location")
-@click.option("-c", "--compress", help="compress=True", is_flag=True, default=False)
+@click.option("-c", "--compress", is_flag=True, default=False, help="Enable LZ4 compression for snapshot files.")
 def create_repository(repository, location, compress):
-    """Create repository."""
+    """Create a shared filesystem snapshot repository.
+
+    The repository is registered at LOCATION/REPOSITORY on the filesystem.
+    The path must be accessible from all SEARCH nodes (e.g. an NFS mount).
+    """
     try:
         snapshot_body = {
             "type": "fs",
-            "settings": {"location": f"{location}/{repository}", "compress": compress},
+            "settings": {"location": os.path.join(location, repository), "compress": compress},
         }
         click.secho(
             json.dumps(
@@ -64,7 +69,11 @@ def create_repository(repository, location, compress):
     prompt="Do you really want to delete a repository?",
 )
 def delete_repository(repository):
-    """Delete a repository."""
+    """Unregister a snapshot repository.
+
+    This removes the repository registration from the cluster but does not
+    delete the underlying snapshot data from the filesystem.
+    """
     try:
         click.secho(
             json.dumps(current_search_client.snapshot.delete_repository(repository), indent=2),

--- a/rero_invenio_base/cli/es/task.py
+++ b/rero_invenio_base/cli/es/task.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Fondation RERO+
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-"""Click elasticsearch tasks command-line utilities."""
+"""Click Search tasks command-line utilities."""
 
 import sys
 from pprint import pformat
@@ -17,16 +17,12 @@ except ImportError:
 
 from invenio_search.cli import with_appcontext
 
-
-def abort_if_false(ctx, param, value):
-    """Abort command is value is False."""
-    if not value:
-        ctx.abort()
+from ..shared import abort_if_false
 
 
 @click.group()
 def task():
-    """Elasticsearch task commands.
+    """Search task commands.
 
     See: https://www.elastic.co/guide/en/elasticsearch/reference/7.10/tasks.html
     """

--- a/rero_invenio_base/cli/shared.py
+++ b/rero_invenio_base/cli/shared.py
@@ -5,6 +5,11 @@
 
 
 def abort_if_false(ctx, param, value):
-    """Abort command is value is False."""
+    """Abort command if value is False.
+
+    :param ctx: Click context object
+    :param param: Click parameter object
+    :param value: Boolean value to check
+    """
     if not value:
         ctx.abort()

--- a/rero_invenio_base/cli/utils.py
+++ b/rero_invenio_base/cli/utils.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Fondation RERO+
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-"""Click elasticsearch command-line utilities."""
+"""Click Search command-line utilities."""
 
 import json
 import os
@@ -45,7 +45,7 @@ def check_json(paths, replace, indent, sort_keys, verbose):
         if os.path.isfile(path):
             files_list.append(path)
         elif os.path.isdir(path):
-            files_list = files_list + glob(os.path.join(path, "**/*.json"), recursive=True)
+            files_list += glob(os.path.join(path, "**/*.json"), recursive=True)
     if not paths:
         files_list = glob("**/*.json", recursive=True)
     tot_error_cnt = 0
@@ -82,4 +82,4 @@ def check_json(paths, replace, indent, sort_keys, verbose):
     sys.exit(tot_error_cnt)
 
 
-__all__ = "utils"
+__all__ = ["utils"]

--- a/rero_invenio_base/modules/export/config.py
+++ b/rero_invenio_base/modules/export/config.py
@@ -6,12 +6,12 @@
 """
   This module must be used to create dynamic export route for resource
   configured by the `invenio-records-rest`. Exports endpoints will provide
-  streamed content. The content is based on an ElasticSearch search result ;
-  this result is processed using ElasticSearch `scan()` method tu fully
+  streamed content. The content is based on a Search search result;
+  this result is processed using Search `scan()` method to fully
   implement streamed result.
 
   Each configured endpoint add a flask blueprint endpoint accessible using the
-  `/export/{resource_list_route/` url.
+  `/export/{resource_list_route}/` url.
 
 
 .. code-block:: python

--- a/rero_invenio_base/modules/export/ext.py
+++ b/rero_invenio_base/modules/export/ext.py
@@ -3,6 +3,8 @@
 
 """RERO Invenio base module declaration for streamed exports."""
 
+from . import config
+
 
 class ReroInvenioBaseExportApp:
     """RERO Invenio base export app."""
@@ -20,6 +22,6 @@ class ReroInvenioBaseExportApp:
 
     def init_config(self, app):
         """Initialize configuration."""
-        for k in dir(app.config):
+        for k in dir(config):
             if k.startswith("RERO_INVENIO_BASE_EXPORT"):
-                app.config.setdefault(k, getattr(app.config, k))
+                app.config.setdefault(k, getattr(config, k))

--- a/rero_invenio_base/modules/export/views.py
+++ b/rero_invenio_base/modules/export/views.py
@@ -23,7 +23,7 @@ def create_blueprint_from_app(app):
         that want to register REST endpoints via the ``RECORDS_REST_ENDPOINTS``
         configuration variable.
 
-    :params app: A Flask application.
+    :param app: A Flask application.
     :returns: Configured blueprint.
     """
     api_blueprint = Blueprint("api_exports", __name__, url_prefix="")
@@ -102,7 +102,7 @@ class ExportResource(ContentNegotiatedMethodView):
     ):
         """Init magic method."""
         serializers = {
-            mime: obj_or_import_string(search_obj) for mime, search_obj in search_serializers.items() or {}.items()
+            mime: obj_or_import_string(search_obj) for mime, search_obj in (search_serializers or {}).items()
         }
         super().__init__(
             method_serializers={"GET": serializers},
@@ -112,7 +112,7 @@ class ExportResource(ContentNegotiatedMethodView):
             **kwargs,
         )
         self.permission_factory = permission_factory
-        self.pid_fetcher = current_pidstore.fetchers[pid_fetcher]
+        self.pid_fetcher = current_pidstore.fetchers[pid_fetcher] if pid_fetcher else None
         self.search_class = search_class
         self.search_factory = partial(search_factory, self)
 

--- a/rero_invenio_base/modules/utils.py
+++ b/rero_invenio_base/modules/utils.py
@@ -3,11 +3,10 @@
 
 """Generic utils functions."""
 
-from collections.abc import Iterable, Iterator
 from itertools import islice
 
 
-def chunk[T](iterable: Iterable[T], size: int) -> Iterator[tuple[T, ...]]:
+def chunk(iterable, size):
     """Split a list of value into a list of chunks.
 
     :param iterable: an iterator or list to be splitted
@@ -18,5 +17,5 @@ def chunk[T](iterable: Iterable[T], size: int) -> Iterator[tuple[T, ...]]:
         list(chunk([1, 2, 3, 4, 5], 2)) == [(1, 2), (3, 4), (5, )]
     """
     it = iter(iterable)
-    while chunk := tuple(islice(it, size)):
-        yield chunk
+    while batch := tuple(islice(it, size)):
+        yield batch

--- a/rero_invenio_base/version.py
+++ b/rero_invenio_base/version.py
@@ -9,4 +9,4 @@ and parsed by ``setup.py``.
 
 from importlib import metadata
 
-__version__ = metadata.version(__package__)
+__version__ = metadata.version("rero-invenio-base")

--- a/scripts/test
+++ b/scripts/test
@@ -60,7 +60,7 @@ trap cleanup EXIT
 
 pip_audit_exceptions=""
 add_exceptions() {
-  pip_audit_exceptions="$pip_audit_exceptions --ignore-vuln $1"""
+  pip_audit_exceptions="$pip_audit_exceptions --ignore-vuln $1"
 }
 
 info_msg "Check vulnerabilities:"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,6 @@ See https://pytest-invenio.readthedocs.io/ for documentation on which test
 fixtures are available.
 """
 
-import contextlib
 import copy
 
 import pytest
@@ -42,7 +41,7 @@ def es_runner(app, es, new_index_name1, new_index_name2):
             ignore=[400, 404],
         )
     search = app.extensions["invenio-search"]
-    with contextlib.suppress(AssertionError):
+    if "records" not in search.aliases:
         search.register_mappings("records", "mock_modules.mappings")
     yield CliRunner()
     for i in [new_index_name1, new_index_name2]:
@@ -76,3 +75,14 @@ def create_app(instance_path):
         return app
 
     return factory
+
+
+@pytest.fixture
+def rebuild_runner(app, es):
+    """Runner for rebuild_index tests; cleans up all records-* indices."""
+    current_search_client.indices.delete(index="records-*", ignore_unavailable=True)
+    search = app.extensions["invenio-search"]
+    if "records" not in search.aliases:
+        search.register_mappings("records", "mock_modules.mappings")
+    yield CliRunner()
+    current_search_client.indices.delete(index="records-*", ignore_unavailable=True)

--- a/tests/test_cli_es.py
+++ b/tests/test_cli_es.py
@@ -3,11 +3,16 @@
 
 """Test cli elasticsearch commands."""
 
+from datetime import UTC, datetime
+
+from invenio_search import current_search, current_search_client
+
 from rero_invenio_base.cli.es.alias import delete_alias, get_alias, put_alias
 from rero_invenio_base.cli.es.index import (
     close_index,
     create_index,
     open_index,
+    rebuild_index,
     switch_index,
     update_mapping,
 )
@@ -60,7 +65,7 @@ def test_cli_es_index_alias(script_info, app, es_runner, new_index_name1, new_in
 
 
 def test_cli_es_snapshot_repository(script_info, app, es_runner, new_index_name1):
-    """Test index and aliases command line interface."""
+    """Test snapshot repository command line interface."""
     runner = es_runner
 
     res = runner.invoke(create_repository, ["tests", "snap"], obj=script_info)
@@ -74,8 +79,134 @@ def test_cli_es_snapshot_repository(script_info, app, es_runner, new_index_name1
     assert res.exit_code == 0
 
 
+def _old_index():
+    """Return a fixed past-dated index name for rebuild tests."""
+    return "records-record-v1.0.0-20250101"
+
+
+def _new_index():
+    """Return the index name rebuild would create today."""
+    registered = next(iter(current_search.aliases.get("records")))
+    return f"{registered}-{datetime.now(UTC).strftime('%Y%m%d')}"
+
+
+def test_rebuild_index_unknown_resource(rebuild_runner, script_info):
+    """Rebuild exits 1 for an unknown alias."""
+    res = rebuild_runner.invoke(rebuild_index, ["nonexistent"], obj=script_info)
+    assert res.exit_code == 1
+    assert "Unknown resource" in res.output
+
+
+def test_rebuild_index_fresh(rebuild_runner, script_info):
+    """Rebuild creates a fresh index and registers the alias when none exist."""
+    res = rebuild_runner.invoke(rebuild_index, ["records", "--no-templates"], obj=script_info)
+    assert res.exit_code == 0
+    assert current_search_client.indices.exists_alias(name="records")
+
+
+def test_rebuild_index_fresh_new_index_already_exists(rebuild_runner, script_info):
+    """Rebuild exits 1 when the target index exists but the alias is missing."""
+    current_search_client.indices.create(index=_new_index(), body={})
+    res = rebuild_runner.invoke(rebuild_index, ["records", "--no-templates"], obj=script_info)
+    assert res.exit_code == 1
+    assert "already exists" in res.output
+
+
+def test_rebuild_index_noop(rebuild_runner, script_info):
+    """Rebuild is a no-op when the alias already points to today's index."""
+    today_index = _new_index()
+    current_search_client.indices.create(index=today_index, body={})
+    current_search_client.indices.put_alias(index=today_index, name="records")
+    res = rebuild_runner.invoke(rebuild_index, ["records", "--no-templates"], obj=script_info)
+    assert res.exit_code == 0
+    assert "Nothing to do" in res.output
+
+
+def test_rebuild_index_new_already_exists(rebuild_runner, script_info):
+    """Rebuild exits 1 when the new index already exists and the alias points elsewhere."""
+    old = _old_index()
+    current_search_client.indices.create(index=old, body={})
+    current_search_client.indices.put_alias(index=old, name="records")
+    current_search_client.indices.create(index=_new_index(), body={})
+    res = rebuild_runner.invoke(rebuild_index, ["records", "--no-templates"], obj=script_info)
+    assert res.exit_code == 1
+    assert "already exists" in res.output
+
+
+def test_rebuild_index_normal_confirm(rebuild_runner, script_info):
+    """Rebuild switches alias and deletes old index when confirmed."""
+    old = _old_index()
+    current_search_client.indices.create(index=old, body={})
+    current_search_client.indices.put_alias(index=old, name="records")
+    res = rebuild_runner.invoke(
+        rebuild_index,
+        ["records", "--no-templates", "--interval", "0"],
+        input="y\n",
+        obj=script_info,
+    )
+    assert res.exit_code == 0
+    assert not current_search_client.indices.exists(index=old)
+    assert current_search_client.indices.exists(index=_new_index())
+    assert current_search_client.indices.exists_alias(name="records")
+
+
+def test_rebuild_index_normal_abort(rebuild_runner, script_info):
+    """Rebuild leaves cluster unchanged when the user declines the confirmation."""
+    old = _old_index()
+    current_search_client.indices.create(index=old, body={})
+    current_search_client.indices.put_alias(index=old, name="records")
+    res = rebuild_runner.invoke(
+        rebuild_index,
+        ["records", "--no-templates", "--interval", "0"],
+        input="n\n",
+        obj=script_info,
+    )
+    assert res.exit_code == 0
+    assert current_search_client.indices.exists(index=old)
+    alias_targets = list(current_search_client.indices.get_alias(name="records").keys())
+    assert alias_targets == [old]
+
+
+def test_rebuild_index_inplace(rebuild_runner, script_info):
+    """--inplace rebuilds under the same name: alias returns to old, temp deleted."""
+    old = _old_index()
+    current_search_client.indices.create(index=old, body={})
+    current_search_client.indices.put_alias(index=old, name="records")
+    res = rebuild_runner.invoke(
+        rebuild_index,
+        ["records", "--no-templates", "--inplace", "--interval", "0"],
+        input="y\ny\n",
+        obj=script_info,
+    )
+    assert res.exit_code == 0
+    assert current_search_client.indices.exists(index=old)
+    alias_targets = list(current_search_client.indices.get_alias(name="records").keys())
+    assert alias_targets == [old]
+    temp_indices = list(current_search_client.indices.get(f"{old}-tmp-*").keys())
+    assert not temp_indices
+
+
+def test_rebuild_index_inplace_abort_second_confirm(rebuild_runner, script_info):
+    """--inplace abort at final confirm: alias stays on temp, old index recreated but not live."""
+    old = _old_index()
+    current_search_client.indices.create(index=old, body={})
+    current_search_client.indices.put_alias(index=old, name="records")
+    res = rebuild_runner.invoke(
+        rebuild_index,
+        ["records", "--no-templates", "--inplace", "--interval", "0"],
+        input="y\nn\n",
+        obj=script_info,
+    )
+    assert res.exit_code == 0
+    temp_indices = list(current_search_client.indices.get(f"{old}-tmp-*").keys())
+    assert len(temp_indices) == 1
+    alias_targets = list(current_search_client.indices.get_alias(name="records").keys())
+    assert alias_targets == temp_indices
+    assert current_search_client.indices.exists(index=old)
+
+
 def test_cli_es_snapshots(script_info, app, es_runner, new_index_name1):
-    """Test index and aliases command line interface."""
+    """Test snapshot lifecycle command line interface."""
     runner = es_runner
 
     res = runner.invoke(create_repository, ["tests", "snap"], obj=script_info)
@@ -86,7 +217,7 @@ def test_cli_es_snapshots(script_info, app, es_runner, new_index_name1):
     res = runner.invoke(list_snapshot, ["tests"], obj=script_info)
     assert res.exit_code == 0
 
-    res = runner.invoke(restore_snapshot, ["snap", "test"], obj=script_info)
+    res = runner.invoke(restore_snapshot, ["snap", "test", "--yes-i-know"], input="y\n", obj=script_info)
 
     assert res.exit_code == 0
     res = runner.invoke(delete_snapshot, ["snap", "test", "--yes-i-know"], obj=script_info)

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -11,7 +11,7 @@ from rero_invenio_base.cli.utils import check_json
 
 
 def test_cli_validate(script_info):
-    """Test JOSON indentation cli."""
+    """Test JSON indentation cli."""
     runner = CliRunner()
     file_name = join(dirname(__file__), "./data/data.json")
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -12,33 +12,24 @@ def test_tasks(capsys):
     """Test celery tasks."""
     code = 'print("simple")'
     run_on_worker(code)
-    capsys.readouterr().out == "simple"
+    assert capsys.readouterr().out == "simple\n"
     code = """
 def display(msg='foo'):
     print(msg)
     return True
     """
     run_on_worker(code, "display")
-    capsys.readouterr().out == "foo"
+    assert capsys.readouterr().out == "foo\n"
 
     run_on_worker(code, "display", msg="named arg")
-    capsys.readouterr().out == "name arg"
+    assert capsys.readouterr().out == "named arg\n"
 
     run_on_worker(code, "display", "arg")
-    capsys.readouterr().out == "arg"
-
-    run_on_worker(code, "display")
-    capsys.readouterr().out == "foo"
-
-    run_on_worker(code, "display", msg="named arg")
-    capsys.readouterr().out == "name arg"
-
-    run_on_worker(code, "display", "arg")
-    capsys.readouterr().out == "arg"
+    assert capsys.readouterr().out == "arg\n"
 
     with pytest.raises(KeyError):
         run_on_worker(code, "foo")
 
     code = 'print(")'
     with pytest.raises(SyntaxError):
-        run_on_worker(code, "display", "arg")
+        run_on_worker(code)


### PR DESCRIPTION
…ment

Replace elasticsearch-dsl with direct client calls, add `rebuild`, `health`, and `queue` commands, and fix several correctness issues across the CLI.

* drop `elasticsearch_dsl.Index` from `index.py` and `snapshot/cli.py`; use `current_search_client.indices.*` with `allow_no_indices=True` and `ignore_unavailable=True` instead
* change default index pattern for `open`/`close` commands from `_all` to `*`
* add `rero es index rebuild <resource>`: zero-data-loss index migration — creates a fresh dated index, reindexes, shows old/new doc counts, asks for confirmation before switching all aliases and deleting the old index
* add `rero es health`: connectivity check for Search, database, and Celery broker; exits 1 if any service is unreachable or in error state
* add `rero es queue list/stats/purge`: inspect Celery workers and queue depths; purge a named queue with `--yes-i-know` guard
* fix `raise click.Abort` → `raise click.Abort()` in `slm/cli.py` (bare reference did nothing)
* fix dead assertions in `tests/test_tasks.py` (missing `assert` keyword) and correct expected output string "name arg" → "named arg"
* fix `__all__ = "rero"` → `__all__ = ["rero"]` in `cli/__init__.py` and `cli/utils.py` (string iterates as characters)
* render `rero es snapshot list` as a formatted table (name, start time, duration, shards, colour-coded state) instead of raw JSON
* add `--names-only` flag to `snapshot list` for scripting use
* improve `create_snapshot --wait` output: show state, duration and shard counts instead of the raw JSON blob
* add `restore_snapshot --delete` flag: deletes RERO ILS indices before restoring
* rename "Elasticsearch"/"OpenSearch" → "Search" throughout docstrings and comments