### PR TITLE
fix(es): refresh dest index before counting docs

### DIFF
--- a/rero_invenio_base/cli/es/index.py
+++ b/rero_invenio_base/cli/es/index.py
@@ -326,6 +326,7 @@ def _reindex_pass(src, dest, interval, verbose, label, src_label, dest_label, co
     if not _do_reindex(src, dest, interval, verbose, label=label):
         sys.exit(exit_base)
 
+    current_search_client.indices.refresh(index=dest)
     src_count = current_search_client.count(index=src).get("count", "?")
     dest_count = current_search_client.count(index=dest).get("count", "?")
     click.secho(f"  {src}: {src_count} docs  ({src_label})", fg="yellow")


### PR DESCRIPTION
* `_reindex_pass` counted `dest` docs right after the reindex task reported completion
* Search's `_count` API only sees refreshed segments, so the count reflected an in-progress refresh state instead of the true number of migrated documents
* Refresh `dest` before counting so the displayed count matches reality